### PR TITLE
Add open_raw_write_stream and open_write_stream APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 
 tests/assets/pulled-from-device.dat
-test/assets/created-via-write-stream.dat
+tests/assets/created-via-write-stream.dat

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 
 tests/assets/pulled-from-device.dat
+test/assets/created-via-write-stream.dat

--- a/src/device/content.rs
+++ b/src/device/content.rs
@@ -3,7 +3,8 @@
 use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_ALL};
 use windows::core::{PCWSTR, GUID};
 use windows::Win32::Devices::PortableDevices::{
-    IPortableDeviceContent, IPortableDeviceKeyCollection, PortableDeviceKeyCollection, WPD_OBJECT_NAME, WPD_OBJECT_CONTENT_TYPE, WPD_DEVICE_OBJECT_ID
+    IPortableDeviceContent, IPortableDeviceKeyCollection, PortableDeviceKeyCollection, WPD_OBJECT_NAME,
+    WPD_OBJECT_CONTENT_TYPE, WPD_OBJECT_ORIGINAL_FILE_NAME, WPD_DEVICE_OBJECT_ID
 };
 use widestring::{U16CString, U16CStr};
 
@@ -46,14 +47,18 @@ impl Content {
 
     /// Get an MTP object given its MTP object ID
     pub fn object_by_id(&self, object_id: U16CString) -> crate::WindowsResult<Object> {
-        // Get object name and type
-        let basic_properties = self.properties(&object_id, &[WPD_OBJECT_NAME, WPD_OBJECT_CONTENT_TYPE])?;
+        // Get the display name, type and the original filename when the device exposes it.
+        let basic_properties = self.properties(
+            &object_id,
+            &[WPD_OBJECT_NAME, WPD_OBJECT_CONTENT_TYPE, WPD_OBJECT_ORIGINAL_FILE_NAME]
+        )?;
 
         let name = basic_properties.get_string(&WPD_OBJECT_NAME)?;
+        let original_file_name = basic_properties.get_string(&WPD_OBJECT_ORIGINAL_FILE_NAME).ok();
         let ty_guid = basic_properties.get_guid(&WPD_OBJECT_CONTENT_TYPE)?;
         let object_type = ObjectType::from_guid(ty_guid);
 
-        Ok(Object::new(self.clone(), object_id, name, object_type))
+        Ok(Object::new(self.clone(), object_id, name, original_file_name, object_type))
     }
 
     /// Get a list of requested metadata about an object.

--- a/src/device/device_values.rs
+++ b/src/device/device_values.rs
@@ -90,6 +90,7 @@ pub(crate) fn make_values_for_create_folder(parent_id: &U16CStr, folder_name: &O
 
     unsafe{ device_values.SetStringValue(&WPD_OBJECT_PARENT_ID as *const _, PCWSTR::from_raw(parent_id.as_ptr())) }?;
     unsafe{ device_values.SetStringValue(&WPD_OBJECT_NAME as *const _, pcwstr_folder_name) }?;
+    unsafe{ device_values.SetStringValue(&WPD_OBJECT_ORIGINAL_FILE_NAME as *const _, pcwstr_folder_name) }?;
     unsafe{ device_values.SetGuidValue(&WPD_OBJECT_CONTENT_TYPE as *const _, &WPD_CONTENT_TYPE_FOLDER as *const _) }?;
 
     Ok(device_values)

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -189,7 +189,7 @@ impl Object {
     /// Also returns the optimal transfer buffer size (in bytes) for this transfer, as stated by the Microsoft API.
     ///
     /// See also [`Self::open_write_stream`].
-    pub fn open_raw_write_stream(&self, file_name: &OsStr, file_size: u64) -> Result<(IStream, u32), AddFileError> {
+    pub fn create_raw_write_stream(&self, file_name: &OsStr, file_size: u64) -> Result<(IStream, u32), AddFileError> {
         let file_properties = make_values_for_create_file(&self.id, file_name, file_size)?;
         make_dest_raw_stream(self.device_content.com_object(), &file_properties)
     }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -1,6 +1,6 @@
 //! MTP object (can be a folder, a file, etc.)
 
-use std::io::BufReader;
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, Components, Component};
 use std::iter::Peekable;
 use std::ffi::OsStr;
@@ -182,6 +182,41 @@ impl Object {
         Ok(BufReader::with_capacity(optimal_transfer_size as usize, read_stream))
     }
 
+    /// Open a COM [`IStream`](windows::Win32::System::Com::IStream) to create a file in the current object.
+    ///
+    /// The current object is expected to be a folder-like object. The file does not exist until the stream is committed.
+    ///
+    /// Also returns the optimal transfer buffer size (in bytes) for this transfer, as stated by the Microsoft API.
+    ///
+    /// See also [`Self::open_write_stream`].
+    pub fn open_raw_write_stream(&self, file_name: &OsStr, file_size: u64) -> Result<(IStream, u32), AddFileError> {
+        let file_properties = make_values_for_create_file(&self.id, file_name, file_size)?;
+        make_dest_raw_stream(self.device_content.com_object(), &file_properties)
+    }
+
+    /// The same as [`Self::open_raw_write_stream`], but wrapped into a [`crate::io::WriteStream`] for more added Rust magic.
+    ///
+    /// The returned stream must be committed, either by calling `flush()` (which calls COM `Commit`) or `commit()`
+    /// on the inner stream.
+    ///
+    /// # Example
+    /// ```
+    /// # let provider = winmtp::Provider::new().unwrap();
+    /// # let basic_device = provider.enumerate_devices().unwrap()[0];
+    /// # let app_identifiers = winmtp::make_current_app_identifiers!();
+    /// # let device = basic_device.open(&app_identifiers).unwrap();
+    /// let destination_folder = device.content().unwrap().root().unwrap();
+    /// let mut output_stream = destination_folder.open_write_stream("pushed-to-device.dat".as_ref(), 5).unwrap();
+    /// use std::io::Write;
+    /// output_stream.write_all(b"hello").unwrap();
+    /// output_stream.flush().unwrap();
+    /// ```
+    pub fn open_write_stream(&self, file_name: &OsStr, file_size: u64) -> Result<BufWriter<WriteStream>, AddFileError> {
+        let (stream, optimal_transfer_size) = self.open_raw_write_stream(file_name, file_size)?;
+        let write_stream = WriteStream::new(stream, optimal_transfer_size as usize);
+        Ok(BufWriter::with_capacity(optimal_transfer_size as usize, write_stream))
+    }
+
     /// Create a subfolder, and return its object ID
     ///
     /// If a folder with the same name already exists ("same name" depends on the chosen case-folding mode), an `CreateFolderError::AlreadyExists` error will be returned.
@@ -240,14 +275,12 @@ impl Object {
         let file_name = local_file.file_name().ok_or(AddFileError::InvalidLocalFile)?;
         let file_size = local_file.metadata()?.len();
         self.remove_existing_file_if_needed(file_name, allow_overwrite)?;
-
-        let file_properties = make_values_for_create_file(&self.id, file_name, file_size)?;
-        let mut dest_writer = make_dest_writer(self.device_content.com_object(), &file_properties)?;
+        let mut dest_writer = self.open_write_stream(file_name, file_size)?;
 
         let mut source_reader = std::fs::File::open(local_file)?;
         std::io::copy(&mut source_reader, &mut dest_writer)?;
 
-        dest_writer.commit()?;
+        dest_writer.flush()?;
 
         Ok(())
     }
@@ -256,14 +289,12 @@ impl Object {
     pub fn push_data(&self, file_name: &OsStr, data: &[u8], allow_overwrite: bool) -> Result<(), AddFileError> {
         let file_size = data.len() as u64;
         self.remove_existing_file_if_needed(file_name, allow_overwrite)?;
-
-        let file_properties = make_values_for_create_file(&self.id, file_name, file_size)?;
-        let mut dest_writer = make_dest_writer(self.device_content.com_object(), &file_properties)?;
+        let mut dest_writer = self.open_write_stream(file_name, file_size)?;
 
         let mut source_reader = std::io::BufReader::new(data);
         std::io::copy(&mut source_reader, &mut dest_writer)?;
 
-        dest_writer.commit()?;
+        dest_writer.flush()?;
 
         Ok(())
     }
@@ -368,7 +399,7 @@ fn object_by_components_last_stage(candidate: Object, next_components: &mut Peek
     }
 }
 
-fn make_dest_writer(com_object: &IPortableDeviceContent, file_properties: &IPortableDeviceValues) -> Result<WriteStream, AddFileError> {
+fn make_dest_raw_stream(com_object: &IPortableDeviceContent, file_properties: &IPortableDeviceValues) -> Result<(IStream, u32), AddFileError> {
     let mut write_stream = None;
     let mut optimal_write_buffer_size = 0;
     unsafe{ com_object.CreateObjectWithPropertiesAndData(
@@ -379,5 +410,5 @@ fn make_dest_writer(com_object: &IPortableDeviceContent, file_properties: &IPort
     )}?;
 
     let write_stream = write_stream.ok_or(AddFileError::UnableToCreate)?;
-    Ok(WriteStream::new(write_stream, optimal_write_buffer_size as usize))
+    Ok((write_stream, optimal_write_buffer_size))
 }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -211,7 +211,7 @@ impl Object {
     /// output_stream.write_all(b"hello").unwrap();
     /// output_stream.flush().unwrap();
     /// ```
-    pub fn open_write_stream(&self, file_name: &OsStr, file_size: u64) -> Result<BufWriter<WriteStream>, AddFileError> {
+    pub fn create_write_stream(&self, file_name: &OsStr, file_size: u64) -> Result<BufWriter<WriteStream>, AddFileError> {
         let (stream, optimal_transfer_size) = self.open_raw_write_stream(file_name, file_size)?;
         let write_stream = WriteStream::new(stream, optimal_transfer_size as usize);
         Ok(BufWriter::with_capacity(optimal_transfer_size as usize, write_stream))

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -38,12 +38,20 @@ pub struct Object {
     id: U16CString,
     /// The object display name (e.g. "PIC_001.jpg")
     name: U16CString,
+    /// The original file name, as exposed by the device for file-like objects.
+    original_file_name: Option<U16CString>,
     ty: ObjectType,
 }
 
 impl Object {
-    pub fn new(device_content: Content, id: U16CString, name: U16CString, ty: ObjectType) -> Self {
-        Self { device_content, id, name, ty }
+    pub fn new(
+        device_content: Content,
+        id: U16CString,
+        name: U16CString,
+        original_file_name: Option<U16CString>,
+        ty: ObjectType
+    ) -> Self {
+        Self { device_content, id, name, original_file_name, ty }
     }
 
     pub(crate) fn device_content(&self) -> &Content {
@@ -57,6 +65,10 @@ impl Object {
     pub fn name(&self) -> &U16CStr {
         // TODO: lazy evaluation (of all properties at once to save calls to properties.GetValues) (depends on how much iterating/filtering by folder is baked-in)?
         &self.name
+    }
+
+    pub fn original_file_name(&self) -> Option<&U16CStr> {
+        self.original_file_name.as_deref()
     }
 
     pub fn object_type(&self) -> ObjectType {
@@ -109,7 +121,12 @@ impl Object {
             Some(Component::Normal(haystack)) => {
                 let candidate = self
                     .children()?
-                    .find(|obj| are_path_eq(obj.name(), haystack, self.device_content.case_sensitive_fs()))
+                    .find(|obj|
+                        are_path_eq(obj.name(), haystack, self.device_content.case_sensitive_fs())
+                        || obj.original_file_name().is_some_and(|original_file_name|
+                            are_path_eq(original_file_name, haystack, self.device_content.case_sensitive_fs())
+                        )
+                    )
                     .ok_or(ItemByPathError::NotFound)?;
 
                 object_by_components_last_stage(candidate, comps)

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -135,7 +135,7 @@ impl Object {
         }
     }
 
-    /// Opens a COM [`IStream`](windows::Win32::System::Com::IStream) to this object.
+    /// Opens a COM [`IStream`](windows::Win32::System::Com::IStream) to this object, suitable for reading.
     ///
     /// An error will be returned if the required operation does not make sense (e.g. get a stream to a folder).
     ///

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -188,7 +188,7 @@ impl Object {
     ///
     /// Also returns the optimal transfer buffer size (in bytes) for this transfer, as stated by the Microsoft API.
     ///
-    /// See also [`Self::open_write_stream`].
+    /// See also [`Self::create_write_stream`].
     pub fn create_raw_write_stream(&self, file_name: &OsStr, file_size: u64) -> Result<(IStream, u32), AddFileError> {
         let file_properties = make_values_for_create_file(&self.id, file_name, file_size)?;
         make_dest_raw_stream(self.device_content.com_object(), &file_properties)
@@ -206,13 +206,13 @@ impl Object {
     /// # let app_identifiers = winmtp::make_current_app_identifiers!();
     /// # let device = basic_device.open(&app_identifiers).unwrap();
     /// let destination_folder = device.content().unwrap().root().unwrap();
-    /// let mut output_stream = destination_folder.open_write_stream("pushed-to-device.dat".as_ref(), 5).unwrap();
+    /// let mut output_stream = destination_folder.create_write_stream("pushed-to-device.dat".as_ref(), 5).unwrap();
     /// use std::io::Write;
     /// output_stream.write_all(b"hello").unwrap();
     /// output_stream.flush().unwrap();
     /// ```
     pub fn create_write_stream(&self, file_name: &OsStr, file_size: u64) -> Result<BufWriter<WriteStream>, AddFileError> {
-        let (stream, optimal_transfer_size) = self.open_raw_write_stream(file_name, file_size)?;
+        let (stream, optimal_transfer_size) = self.create_raw_write_stream(file_name, file_size)?;
         let write_stream = WriteStream::new(stream, optimal_transfer_size as usize);
         Ok(BufWriter::with_capacity(optimal_transfer_size as usize, write_stream))
     }
@@ -275,7 +275,7 @@ impl Object {
         let file_name = local_file.file_name().ok_or(AddFileError::InvalidLocalFile)?;
         let file_size = local_file.metadata()?.len();
         self.remove_existing_file_if_needed(file_name, allow_overwrite)?;
-        let mut dest_writer = self.open_write_stream(file_name, file_size)?;
+        let mut dest_writer = self.create_write_stream(file_name, file_size)?;
 
         let mut source_reader = std::fs::File::open(local_file)?;
         std::io::copy(&mut source_reader, &mut dest_writer)?;
@@ -289,7 +289,7 @@ impl Object {
     pub fn push_data(&self, file_name: &OsStr, data: &[u8], allow_overwrite: bool) -> Result<(), AddFileError> {
         let file_size = data.len() as u64;
         self.remove_existing_file_if_needed(file_name, allow_overwrite)?;
-        let mut dest_writer = self.open_write_stream(file_name, file_size)?;
+        let mut dest_writer = self.create_write_stream(file_name, file_size)?;
 
         let mut source_reader = std::io::BufReader::new(data);
         std::io::copy(&mut source_reader, &mut dest_writer)?;

--- a/tests/file_access.rs
+++ b/tests/file_access.rs
@@ -1,6 +1,7 @@
 //! These test should succeed when an Android device is connected.
 
 use std::ffi::OsStr;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use widestring::U16CString;
@@ -73,6 +74,9 @@ impl DeviceKind {
         // r"Internal shared storage\Download\winmtp_test\Rough Draft (open source mp3 from audiohub.com).mp3"
         PathBuf::from(format!(r"{}\{}\winmtp_test\Rough Draft (open source mp3 from audiohub.com).mp3", self.storage_root_name(), self.downloads_dir_name()))
     }
+    fn write_stream_file_path(&self) -> PathBuf {
+        PathBuf::from(format!(r"{}\{}\winmtp_test_stream\Rough Draft (open source mp3 from audiohub.com).mp3", self.storage_root_name(), self.downloads_dir_name()))
+    }
 }
 
 fn get_device_kind(basic_device: &BasicDevice) -> DeviceKind {
@@ -97,6 +101,8 @@ fn file_access() {
     access_by_id(first_device, &device_kind);
     push_content(first_device, &device_kind);
     pull_content(first_device, &device_kind);
+    writes_file_via_create_write_stream(first_device, &device_kind);
+    verifies_file_written_via_create_write_stream(first_device, &device_kind);
 }
 
 fn access_by_path(basic_device: &BasicDevice, device_kind: &DeviceKind) {
@@ -179,6 +185,34 @@ fn push_content(basic_device: &BasicDevice, device_kind: &DeviceKind) {
     test_folder.push_file(Path::new(EXAMPLE_FILE), true).unwrap();
 }
 
+fn writes_file_via_create_write_stream(basic_device: &BasicDevice, device_kind: &DeviceKind) {
+    let app_identifiers = winmtp::make_current_app_identifiers!();
+    let device = basic_device.open(&app_identifiers, true).unwrap();
+    let content = device.content().unwrap();
+    let download_folder = content.root().unwrap().object_by_path(&device_kind.downloads_dir_path()).unwrap();
+    let test_folder_id = match download_folder.create_subfolder(OsStr::new("winmtp_test_stream")) {
+        Ok(id) => id,
+        Err(winmtp::error::CreateFolderError::AlreadyExists) => {
+            let mut existing_folder = download_folder.object_by_path(Path::new("winmtp_test_stream")).unwrap();
+            existing_folder.delete(true).unwrap();
+            // and try again
+            download_folder.create_subfolder(OsStr::new("winmtp_test_stream")).unwrap()
+        }
+        Err(err) => panic!("{}", err),
+    };
+
+    let test_folder = content.object_by_id(test_folder_id).unwrap();
+    let file_size = std::fs::metadata(Path::new(EXAMPLE_FILE)).unwrap().len();
+    let file_name = Path::new(EXAMPLE_FILE).file_name().unwrap();
+    let mut source_file = std::fs::File::open(Path::new(EXAMPLE_FILE)).unwrap();
+    
+    let mut output_stream = test_folder
+        .create_write_stream(file_name, file_size)
+        .unwrap();
+    std::io::copy(&mut source_file, &mut output_stream).unwrap();
+    output_stream.flush().unwrap();
+}
+
 fn pull_content(basic_device: &BasicDevice, device_kind: &DeviceKind) {
     let app_identifiers = winmtp::make_current_app_identifiers!();
     let device = basic_device.open(&app_identifiers, true).unwrap();
@@ -193,6 +227,23 @@ fn pull_content(basic_device: &BasicDevice, device_kind: &DeviceKind) {
     // Download the file
     let mut input_stream = object.open_read_stream().unwrap();
     let mut output_file = std::fs::File::create(r"tests\assets\pulled-from-device.dat").unwrap();
+    std::io::copy(&mut input_stream, &mut output_file).unwrap();
+}
+
+fn verifies_file_written_via_create_write_stream(basic_device: &BasicDevice, device_kind: &DeviceKind) {
+    let app_identifiers = winmtp::make_current_app_identifiers!();
+    let device = basic_device.open(&app_identifiers, true).unwrap();
+    let object = device.content().unwrap().root().unwrap().object_by_path(&device_kind.write_stream_file_path()).unwrap();
+
+    // Check the file size
+    let metadata = object.properties(&[WPD_OBJECT_SIZE]).unwrap();
+    let retrieved_size = metadata.get_u32(&WPD_OBJECT_SIZE).unwrap();
+    let original_size = std::fs::metadata(Path::new(EXAMPLE_FILE)).unwrap().len();
+    assert_eq!(retrieved_size as u64, original_size);
+
+    // Download the file
+    let mut input_stream = object.open_read_stream().unwrap();
+    let mut output_file = std::fs::File::create(r"tests\assets\created-via-write-stream.dat").unwrap();
     std::io::copy(&mut input_stream, &mut output_file).unwrap();
 }
 

--- a/tests/file_access.rs
+++ b/tests/file_access.rs
@@ -1,7 +1,7 @@
 //! These test should succeed when an Android device is connected.
 
 use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use widestring::U16CString;
 
@@ -13,6 +13,76 @@ use winmtp::object::ObjectType;
 
 const EXAMPLE_FILE: &str = r"tests\assets\Rough Draft (open source mp3 from audiohub.com).mp3";
 
+enum DeviceKind {
+    GenericAndroid,
+    Kindle
+}
+
+impl DeviceKind {
+    fn storage_root_name(&self) -> &'static str {
+        match self {
+            DeviceKind::GenericAndroid => "Internal shared storage",
+            DeviceKind::Kindle => "Internal Storage",
+        }
+    }
+
+    fn downloads_dir_name(&self) -> &'static str {
+        match self {
+            DeviceKind::GenericAndroid => "Download",
+            DeviceKind::Kindle => "downloads",
+        }
+    }
+
+    fn downloads_dir_path(&self) -> PathBuf {
+        // r"Internal shared storage\Download\"
+        PathBuf::from(format!(r"{}\{}\", self.storage_root_name(), self.downloads_dir_name()))
+    }
+    fn downloads_dir_path_with_dot_segments(&self) -> PathBuf {
+        // r"Internal shared storage\.\.\Download\.\"
+        PathBuf::from(format!(r"{}\.\.\{}\.\", self.storage_root_name(), self.downloads_dir_name()))
+    }
+    fn download_path_playlist_file(&self) -> PathBuf {
+        // r"Internal shared storage\.\.\Download\.\some_playlist.m3u"
+        PathBuf::from(format!(r"{}\.\.\{}\.\some_playlist.m3u", self.storage_root_name(), self.downloads_dir_name()))
+    }
+    fn downloads_dir_path_with_redundant_separators(&self) -> PathBuf {
+        // r"Internal shared storage\\\Download\\\"
+        PathBuf::from(format!(r"{}\\\{}\\\", self.storage_root_name(), self.downloads_dir_name()))
+    }
+    fn nonexistent_path_under_downloads(&self) -> PathBuf {
+        // r"Internal shared storage\\\Download\\\this_does_not_exist"
+        PathBuf::from(format!(r"{}\\\{}\\\this_does_not_exist", self.storage_root_name(), self.downloads_dir_name()))
+    }
+    fn downloads_dir_path_with_parent_roundtrip(&self) -> PathBuf {
+        // r"Internal shared storage\\\Download\\\..\Download"
+        PathBuf::from(format!(r"{}\\\{}\\\..\{}", self.storage_root_name(), self.downloads_dir_name(), self.downloads_dir_name()))
+    }
+    fn downloads_dir_path_with_nested_parent_segments(&self) -> PathBuf {
+        // r"Internal shared storage\\\Download\\\CYA\..\..\Download"
+        PathBuf::from(format!(r"{}\\\{}\\\CYA\..\..\{}", self.storage_root_name(), self.downloads_dir_name(), self.downloads_dir_name()))
+    }
+    fn storage_root_parent_path(&self) -> PathBuf {
+        // r"Internal shared storage\.."
+        PathBuf::from(format!(r"{}\..", self.storage_root_name()))
+    }
+    fn storage_root_parent_path_with_trailing_slash(&self) -> PathBuf {
+        // r"Internal shared storage\..\"
+        PathBuf::from(format!(r"{}\..\", self.storage_root_name()))
+    }
+    fn uploaded_mp3_path(&self) -> PathBuf {
+        // r"Internal shared storage\Download\winmtp_test\Rough Draft (open source mp3 from audiohub.com).mp3"
+        PathBuf::from(format!(r"{}\{}\winmtp_test\Rough Draft (open source mp3 from audiohub.com).mp3", self.storage_root_name(), self.downloads_dir_name()))
+    }
+}
+
+fn get_device_kind(basic_device: &BasicDevice) -> DeviceKind {
+    match basic_device.friendly_name().to_lowercase() {
+        s if s.contains("kindle") => DeviceKind::Kindle,
+        s if s.contains("android") => DeviceKind::GenericAndroid,
+        s => panic!("No testing paths for friendly name {}", s) 
+    }
+}
+
 #[test]
 fn file_access() {
     // This is a manual smoke test rather than a proper automated test, as this requires a device to be connected, with some assumptions about its content
@@ -20,15 +90,16 @@ fn file_access() {
     let provider = Provider::new().unwrap();
     let devices = provider.enumerate_devices().unwrap();
     let first_device = devices.get(0).expect("a device to be connected");
+    let device_kind = get_device_kind(first_device);
 
     println!("Testing on {}:", first_device.friendly_name());
-    access_by_path(first_device);
-    access_by_id(first_device);
-    push_content(first_device);
-    pull_content(first_device);
+    access_by_path(first_device, &device_kind);
+    access_by_id(first_device, &device_kind);
+    push_content(first_device, &device_kind);
+    pull_content(first_device, &device_kind);
 }
 
-fn access_by_path(basic_device: &BasicDevice) {
+fn access_by_path(basic_device: &BasicDevice, device_kind: &DeviceKind) {
     let app_ident = winmtp::make_current_app_identifiers!();
 
     let device = basic_device.open(&app_ident, true).unwrap();
@@ -37,34 +108,38 @@ fn access_by_path(basic_device: &BasicDevice) {
     let root_obj = content.root().unwrap();
     assert_eq!(root_obj.object_type(), ObjectType::FunctionalObject);
 
-    let object_by_path = root_obj.object_by_path(Path::new(r"Internal shared storage\Download\")).unwrap();
+    let object_by_path = root_obj.object_by_path(Path::new(&device_kind.downloads_dir_path())).unwrap();
     assert_eq!(object_by_path.object_type(), ObjectType::Folder);
 
-    let object_by_path = root_obj.object_by_path(Path::new(r"Internal shared storage\.\.\Download\.\")).unwrap();
+    let object_by_path = root_obj.object_by_path(Path::new(&device_kind.downloads_dir_path_with_dot_segments())).unwrap();
     assert_eq!(object_by_path.object_type(), ObjectType::Folder);
 
-    let object_by_path = root_obj.object_by_path(Path::new(r"Internal shared storage\.\.\Download\.\some_playlist.m3u")).unwrap();
-    assert_eq!(object_by_path.object_type(), ObjectType::Playlist);
+    let object_by_path = root_obj.object_by_path(Path::new(&device_kind.download_path_playlist_file())).unwrap();
+    match device_kind {
+        // kindles seem to report the object_type of .m3u files as unspecified
+        DeviceKind::Kindle => assert_eq!(object_by_path.object_type(), ObjectType::Unspecified),
+        _ => assert_eq!(object_by_path.object_type(), ObjectType::Playlist)
+    }   
 
-    let object_by_path = root_obj.object_by_path(Path::new(r"Internal shared storage\\\Download\\\")).unwrap();
+    let object_by_path = root_obj.object_by_path(&device_kind.downloads_dir_path_with_redundant_separators()).unwrap();
     assert_eq!(object_by_path.object_type(), ObjectType::Folder);
 
-    let object_by_path = root_obj.object_by_path(Path::new(r"Internal shared storage\\\Download\\\this_does_not_exist"));
+    let object_by_path = root_obj.object_by_path(&device_kind.nonexistent_path_under_downloads());
     assert!(object_by_path.is_err());
 
-    let object_by_path = root_obj.object_by_path(Path::new(r"Internal shared storage\\\Download\\\..\Download")).unwrap();
+    let object_by_path = root_obj.object_by_path(Path::new(&device_kind.downloads_dir_path_with_parent_roundtrip())).unwrap();
     assert_eq!(object_by_path.object_type(), ObjectType::Folder);
 
-    let object_by_path = root_obj.object_by_path(Path::new(r"Internal shared storage\\\Download\\\CYA\..\..\Download")).unwrap();
+    let object_by_path = root_obj.object_by_path(Path::new(&device_kind.downloads_dir_path_with_nested_parent_segments())).unwrap();
     assert_eq!(object_by_path.object_type(), ObjectType::Folder);
 
     let object_by_path = root_obj.object_by_path(Path::new(r".")).unwrap();
     assert_eq!(object_by_path.object_type(), ObjectType::FunctionalObject);
 
-    let object_by_path = root_obj.object_by_path(Path::new(r"Internal shared storage\..")).unwrap();
+    let object_by_path = root_obj.object_by_path(Path::new(&device_kind.storage_root_parent_path())).unwrap();
     assert_eq!(object_by_path.object_type(), ObjectType::FunctionalObject);
 
-    let object_by_path = root_obj.object_by_path(Path::new(r"Internal shared storage\..\")).unwrap();
+    let object_by_path = root_obj.object_by_path(Path::new(&device_kind.storage_root_parent_path_with_trailing_slash())).unwrap();
     assert_eq!(object_by_path.object_type(), ObjectType::FunctionalObject);
 
     let object_by_path = root_obj.object_by_path(Path::new(r".."));
@@ -72,23 +147,23 @@ fn access_by_path(basic_device: &BasicDevice) {
 }
 
 
-fn access_by_id(basic_device: &BasicDevice) {
+fn access_by_id(basic_device: &BasicDevice, device_kind: &DeviceKind) {
     let app_ident = winmtp::make_current_app_identifiers!();
 
     let device = basic_device.open(&app_ident, true).unwrap();
     let content = device.content().unwrap();
 
     let root_obj = content.root().unwrap();
-    let download_folder_by_path = root_obj.object_by_path(Path::new(r"Internal shared storage\Download\")).unwrap();
+    let download_folder_by_path = root_obj.object_by_path(&device_kind.downloads_dir_path()).unwrap();
     let download_folder_by_id = content.object_by_id(download_folder_by_path.id().to_ucstring()).unwrap();
-    assert_eq!(download_folder_by_id.name(), &U16CString::from_str_truncate("Download"));
+    assert_eq!(download_folder_by_id.name(), &U16CString::from_str_truncate(device_kind.downloads_dir_name()));
 }
 
-fn push_content(basic_device: &BasicDevice) {
+fn push_content(basic_device: &BasicDevice, device_kind: &DeviceKind) {
     let app_identifiers = winmtp::make_current_app_identifiers!();
     let device = basic_device.open(&app_identifiers, true).unwrap();
     let content = device.content().unwrap();
-    let download_folder = content.root().unwrap().object_by_path(Path::new(r"Internal shared storage\Download\")).unwrap();
+    let download_folder = content.root().unwrap().object_by_path(&device_kind.downloads_dir_path()).unwrap();
     let test_folder_id = match download_folder.create_subfolder(OsStr::new("winmtp_test")) {
         Ok(id) => id,
         Err(winmtp::error::CreateFolderError::AlreadyExists) => {
@@ -104,10 +179,10 @@ fn push_content(basic_device: &BasicDevice) {
     test_folder.push_file(Path::new(EXAMPLE_FILE), true).unwrap();
 }
 
-fn pull_content(basic_device: &BasicDevice) {
+fn pull_content(basic_device: &BasicDevice, device_kind: &DeviceKind) {
     let app_identifiers = winmtp::make_current_app_identifiers!();
     let device = basic_device.open(&app_identifiers, true).unwrap();
-    let object = device.content().unwrap().root().unwrap().object_by_path(Path::new(r"Internal shared storage\Download\winmtp_test\Rough Draft (open source mp3 from audiohub.com).mp3")).unwrap();
+    let object = device.content().unwrap().root().unwrap().object_by_path(&device_kind.uploaded_mp3_path()).unwrap();
 
     // Check the file size
     let metadata = object.properties(&[WPD_OBJECT_SIZE]).unwrap();


### PR DESCRIPTION
I've added low-level `open_raw_write_stream` and the more ergonomic `open_write_stream` methods that open write streams for object uploads. This makes it possible to achieve the progress bar functionality mentioned in #6.

I think this is a good first step to implement and a basis on that something like `push_file_with_callback` can be built.

I tried to make the impl similar to the existing implementation of the `open_raw_stream` and `open_stream`. I'm not sure about putting file_name and file_size in the arguments and the return type. Please suggest improvements if you have any.